### PR TITLE
#24 Hibernate instances if possible

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,5 +1,5 @@
 # @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
-pnpm-lock.yaml=66724364
-package.json=-82607200
+pnpm-lock.yaml=2107841750
+package.json=1824802771

--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,5 +1,5 @@
 # @generated
 # Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
-pnpm-lock.yaml=1019986523
-package.json=-1240815141
+pnpm-lock.yaml=66724364
+package.json=-82607200

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,7 @@ load("@npm//:@vscode/vsce/package_json.bzl", "bin")
 load("@aspect_rules_js//npm:defs.bzl", "stamped_package_json")
 load("@npm//:ttypescript/package_json.bzl", ttsc_bin = "bin")
 load("ts_project.bzl", "ts_project")
+load("@rules_pkg//:pkg.bzl", "pkg_zip")
 
 platforms()
 
@@ -45,6 +46,7 @@ deps = [
     "//:node_modules/validator",
     "//:node_modules/yargs",
     "//:node_modules/ts-transformer-keys",
+    "//:node_modules/@types/aws-lambda",
 ]
 
 tests = ["*.test.ts"]
@@ -118,7 +120,27 @@ session_manager(
 cdk_app_file_name = "app.cjs"
 
 cjs_bundle(
+    name = "stop_handler",
+    entry_point = "stopHandler.js",
+    external_libs = ["@aws-sdk/*"],
+    minify = minify,
+    output = "stopHandler.cjs",
+    sourcemap = sourcemap,
+)
+
+pkg_zip(
+    name = "stopper_bundle",
+    srcs = [
+        "stop_handler",
+    ],
+)
+
+cjs_bundle(
     name = "cdk_app",
+    define = {
+        "process.env.STOPPER_ZIP": '"stopper_bundle.zip"',
+        "process.env.STOPPER_HANDLER": '"stopHandler.handler"',
+    },
     entry_point = "app.js",
     external_libs = external_libs,
     minify = minify,
@@ -154,6 +176,7 @@ npm_package(
         "cdk_app",
         "package",
         "extension",
+        "stopper_bundle",
         "ssm_proxy_script",
         "README.md",
         "LICENSE.txt",

--- a/InstancePropsResolver.ts
+++ b/InstancePropsResolver.ts
@@ -90,22 +90,24 @@ export class InstancePropsResolver {
       initOptions,
       role: this.toRole(request.stackName as string, construct),
       hibernationOptions: {
-        configured: await this.isHibernationSupported(instanceType)
-      }
+        configured: await this.isHibernationSupported(instanceType),
+      },
     };
   }
 
   async isHibernationSupported(instanceType: InstanceType): Promise<boolean> {
     const instanceTypeString = instanceType.toString();
     const ec2 = await this.clientFactory.createAwsClientPromise(EC2Client);
-    const response = await ec2.send(new DescribeInstanceTypesCommand({
-        InstanceTypes: [
-          instanceTypeString
-        ]
-    }));
-    const instanceInfo = response.InstanceTypes?.find(i => i.InstanceType === instanceTypeString);
+    const response = await ec2.send(
+      new DescribeInstanceTypesCommand({
+        InstanceTypes: [instanceTypeString],
+      })
+    );
+    const instanceInfo = response.InstanceTypes?.find(
+      (i) => i.InstanceType === instanceTypeString
+    );
     return !!instanceInfo?.HibernationSupported;
-}
+  }
 
   toRole(stackName: string, construct: Construct): IRole {
     const roleName = `${stackName}InstanceRole`;

--- a/InstancePropsResolver.ts
+++ b/InstancePropsResolver.ts
@@ -1,5 +1,6 @@
 import {
   DescribeImagesCommand,
+  DescribeInstanceTypesCommand,
   EC2Client,
   Image,
   PlatformValues,
@@ -88,8 +89,23 @@ export class InstancePropsResolver {
       init,
       initOptions,
       role: this.toRole(request.stackName as string, construct),
+      hibernationOptions: {
+        configured: await this.isHibernationSupported(instanceType)
+      }
     };
   }
+
+  async isHibernationSupported(instanceType: InstanceType): Promise<boolean> {
+    const instanceTypeString = instanceType.toString();
+    const ec2 = await this.clientFactory.createAwsClientPromise(EC2Client);
+    const response = await ec2.send(new DescribeInstanceTypesCommand({
+        InstanceTypes: [
+          instanceTypeString
+        ]
+    }));
+    const instanceInfo = response.InstanceTypes?.find(i => i.InstanceType === instanceTypeString);
+    return !!instanceInfo?.HibernationSupported;
+}
 
   toRole(stackName: string, construct: Construct): IRole {
     const roleName = `${stackName}InstanceRole`;

--- a/InstancePropsResolver.ts
+++ b/InstancePropsResolver.ts
@@ -82,7 +82,7 @@ export class InstancePropsResolver {
       blockDevices: [
         {
           deviceName,
-          volume: BlockDeviceVolume.ebs(rootVolumeSizeGb),
+          volume: BlockDeviceVolume.ebs(rootVolumeSizeGb, {encrypted: true}),
         },
       ],
       init,

--- a/InstancePropsResolver.ts
+++ b/InstancePropsResolver.ts
@@ -82,7 +82,7 @@ export class InstancePropsResolver {
       blockDevices: [
         {
           deviceName,
-          volume: BlockDeviceVolume.ebs(rootVolumeSizeGb, {encrypted: true}),
+          volume: BlockDeviceVolume.ebs(rootVolumeSizeGb, { encrypted: true }),
         },
       ],
       init,

--- a/InstanceStarter.ts
+++ b/InstanceStarter.ts
@@ -3,7 +3,7 @@ import {
   StartInstancesCommand,
   StopInstancesCommand,
   InstanceStateName,
-  EC2ServiceException
+  EC2ServiceException,
 } from "@aws-sdk/client-ec2";
 import { InstanceStateResolver } from "./InstanceStateResolver";
 import { AwsClientFactory } from "./AwsClientFactory";
@@ -91,18 +91,18 @@ export class InstanceStarter {
       await client.send(
         new StopInstancesCommand({
           ...request,
-          Hibernate: true
+          Hibernate: true,
         })
       );
     } catch (err) {
-      if ((err as EC2ServiceException).name === "UnsupportedHibernationConfiguration") {
-        await client.send(
-          new StopInstancesCommand(request)
-        );
+      if (
+        (err as EC2ServiceException).name ===
+        "UnsupportedHibernationConfiguration"
+      ) {
+        await client.send(new StopInstancesCommand(request));
       } else {
         throw err;
       }
     }
-
   }
 }

--- a/InstanceStarter.ts
+++ b/InstanceStarter.ts
@@ -85,6 +85,7 @@ export class InstanceStarter {
     const client = await this.serviceFactory.createAwsClientPromise(EC2Client);
     await client.send(
       new StopInstancesCommand({
+        Hibernate: true,
         InstanceIds: [instanceId],
       })
     );

--- a/InstanceStore.ts
+++ b/InstanceStore.ts
@@ -18,8 +18,8 @@ import {
 } from "rxjs";
 import { AwsClientFactory } from "./AwsClientFactory";
 import { toPromise } from "./toPromise";
-import { flatten } from "./flatten";
-import { isEqual } from "lodash";
+import flatten from "lodash/flatten";
+import isEqual from "lodash/isEqual";
 
 export class InstanceStore {
   public readonly changes: Observable<string[]>;

--- a/StopAlarmActionStrategy.ts
+++ b/StopAlarmActionStrategy.ts
@@ -1,14 +1,13 @@
-import {
-  Ec2Action,
-  Ec2InstanceAction,
-} from "aws-cdk-lib/aws-cloudwatch-actions";
+import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
+import { Topic } from "aws-cdk-lib/aws-sns";
 import {
   AlarmActionStrategyProps,
   IAlarmActionStrategy,
 } from "cdk-monitoring-constructs";
 
 export class StopAlarmActionStrategy implements IAlarmActionStrategy {
+  constructor(private topic: Topic) {}
   addAlarmActions(props: AlarmActionStrategyProps): void {
-    props.alarm.addAlarmAction(new Ec2Action(Ec2InstanceAction.STOP));
+    props.alarm.addAlarmAction(new SnsAction(this.topic));
   }
 }

--- a/StopperEnvVar.ts
+++ b/StopperEnvVar.ts
@@ -1,3 +1,3 @@
 export enum StopperEnvVar {
-    InstanceId = "INSTANCE_ID"
+  InstanceId = "INSTANCE_ID",
 }

--- a/StopperEnvVar.ts
+++ b/StopperEnvVar.ts
@@ -1,0 +1,3 @@
+export enum StopperEnvVar {
+    InstanceId = "INSTANCE_ID"
+}

--- a/VscInstance.ts
+++ b/VscInstance.ts
@@ -15,7 +15,7 @@ export class VscInstance extends Construct {
     super(scope, id);
     this.instance = new Instance(this, "Instance", props);
     this.instance.instance.hibernationOptions = {
-      configured: true
+      configured: true,
     };
     this.monitoring = new MonitoringFacade(
       this,

--- a/VscInstance.ts
+++ b/VscInstance.ts
@@ -84,6 +84,6 @@ export class VscInstance extends Construct {
 
   toArn(instanceId: string): string {
     const stack = Stack.of(this);
-    return `arn:aws:ec2${stack.region}:${stack.account}:instance/${instanceId}`;
+    return `arn:aws:ec2:${stack.region}:${stack.account}:instance/${instanceId}`;
   }
 }

--- a/VscInstance.ts
+++ b/VscInstance.ts
@@ -14,6 +14,9 @@ export class VscInstance extends Construct {
   constructor(scope: Construct, id: string, props: VscInstanceProps) {
     super(scope, id);
     this.instance = new Instance(this, "Instance", props);
+    this.instance.instance.hibernationOptions = {
+      configured: true
+    };
     this.monitoring = new MonitoringFacade(
       this,
       `${props.alarmNamePrefix}Monitoring`,

--- a/VscInstance.ts
+++ b/VscInstance.ts
@@ -13,6 +13,7 @@ import { StopperEnvVar } from "./StopperEnvVar";
 import { Runtime, Function, Code } from "aws-cdk-lib/aws-lambda";
 import { SnsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { join } from "path";
 export class VscInstance extends Construct {
   public readonly topic: Topic;
   public readonly instance: Instance;
@@ -46,7 +47,7 @@ export class VscInstance extends Construct {
     this.stopper = new Function(this, "Stopper", {
       runtime: Runtime.NODEJS_18_X,
       environment: stopperEnv,
-      code: Code.fromAsset(process.env.STOPPER_ZIP as string),
+      code: Code.fromAsset(join(__dirname, process.env.STOPPER_ZIP as string)),
       handler: process.env.STOPPER_HANDLER as string,
     });
     this.stopperSource = new SnsEventSource(this.topic);

--- a/VscInstance.ts
+++ b/VscInstance.ts
@@ -14,9 +14,7 @@ export class VscInstance extends Construct {
   constructor(scope: Construct, id: string, props: VscInstanceProps) {
     super(scope, id);
     this.instance = new Instance(this, "Instance", props);
-    this.instance.instance.hibernationOptions = {
-      configured: true,
-    };
+    this.instance.instance.hibernationOptions = props.hibernationOptions;
     this.monitoring = new MonitoringFacade(
       this,
       `${props.alarmNamePrefix}Monitoring`,

--- a/VscInstanceProps.ts
+++ b/VscInstanceProps.ts
@@ -1,5 +1,6 @@
-import { InstanceProps } from "aws-cdk-lib/aws-ec2";
+import { CfnInstance, InstanceProps } from "aws-cdk-lib/aws-ec2";
 
 export interface VscInstanceProps extends InstanceProps {
   alarmNamePrefix: string;
+  hibernationOptions: CfnInstance.HibernationOptionsProperty
 }

--- a/VscInstanceProps.ts
+++ b/VscInstanceProps.ts
@@ -2,5 +2,5 @@ import { CfnInstance, InstanceProps } from "aws-cdk-lib/aws-ec2";
 
 export interface VscInstanceProps extends InstanceProps {
   alarmNamePrefix: string;
-  hibernationOptions: CfnInstance.HibernationOptionsProperty
+  hibernationOptions: CfnInstance.HibernationOptionsProperty;
 }

--- a/flatten.ts
+++ b/flatten.ts
@@ -1,5 +1,0 @@
-import { flattener } from "./flattener";
-
-export function flatten<T>(input: T[][]): T[] {
-  return input.reduce(flattener, []);
-}

--- a/flattener.ts
+++ b/flattener.ts
@@ -1,4 +1,0 @@
-export const flattener = <T>(previous: T[], current: T[]): T[] => [
-  ...previous,
-  ...current,
-];

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@aws-sdk/credential-providers": "3.369.0",
     "@aws-sdk/shared-ini-file-loader": "3.369.0",
     "aws-cdk-lib": "2.87.0",
-    "cdk-monitoring-constructs": "4.0.2",
+    "cdk-monitoring-constructs": "5.3.3",
     "constructs": "10.2.69",
     "lodash": "4.17.21",
     "sshpk": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "aws-cdk": "2.87.0",
+    "@types/aws-lambda": "8.10.119",
     "@types/validator": "13.7.14",
     "@types/lodash": "4.14.192",
     "@types/vscode": "1.76.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: 2.87.0
     version: 2.87.0(constructs@10.2.69)
   cdk-monitoring-constructs:
-    specifier: 4.0.2
-    version: 4.0.2(@aws-cdk/aws-apigatewayv2-alpha@2.65.0-alpha.0)(@aws-cdk/aws-redshift-alpha@2.65.0-alpha.0)(@aws-cdk/aws-synthetics-alpha@2.65.0-alpha.0)(aws-cdk-lib@2.87.0)(constructs@10.2.69)
+    specifier: 5.3.3
+    version: 5.3.3(@aws-cdk/aws-apigatewayv2-alpha@2.65.0-alpha.0)(@aws-cdk/aws-redshift-alpha@2.65.0-alpha.0)(@aws-cdk/aws-synthetics-alpha@2.65.0-alpha.0)(aws-cdk-lib@2.87.0)(constructs@10.2.69)
   constructs:
     specifier: 10.2.69
     version: 10.2.69
@@ -2240,8 +2240,8 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: false
 
-  /cdk-monitoring-constructs@4.0.2(@aws-cdk/aws-apigatewayv2-alpha@2.65.0-alpha.0)(@aws-cdk/aws-redshift-alpha@2.65.0-alpha.0)(@aws-cdk/aws-synthetics-alpha@2.65.0-alpha.0)(aws-cdk-lib@2.87.0)(constructs@10.2.69):
-    resolution: {integrity: sha512-3+OruZkl17e8MRTYt4fUUabXfQSDOwzrbVZ5bD25ybH1sRzdrFP/bfaSp2omQ8DdW67TKYDFQKde/LPoOD1LJg==}
+  /cdk-monitoring-constructs@5.3.3(@aws-cdk/aws-apigatewayv2-alpha@2.65.0-alpha.0)(@aws-cdk/aws-redshift-alpha@2.65.0-alpha.0)(@aws-cdk/aws-synthetics-alpha@2.65.0-alpha.0)(aws-cdk-lib@2.87.0)(constructs@10.2.69):
+    resolution: {integrity: sha512-vZWaJ7DyzYWWx24cZLuxN+5WCUEmcybfOLBI5PxZGM673dgykF3kZp/IThHrNorkm/DdwKsc2JIq9ZL9CcRHmQ==}
     peerDependencies:
       '@aws-cdk/aws-apigatewayv2-alpha': ^2.65.0-alpha.0
       '@aws-cdk/aws-redshift-alpha': ^2.65.0-alpha.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ dependencies:
     version: 17.7.1
 
 devDependencies:
+  '@types/aws-lambda':
+    specifier: 8.10.119
+    version: 8.10.119
   '@types/jest':
     specifier: 29.5.0
     version: 29.5.0
@@ -1795,6 +1798,10 @@ packages:
     resolution: {integrity: sha512-5TMxIpYbIA9c1J0hYQjQDX3wr+rTgQEAXaW2BI8ECM8FO53wSW4HFZplTalrKSHuZUc76NtXcePRhwuOHqGD5g==}
     dependencies:
       '@types/node': 18.15.5
+    dev: true
+
+  /@types/aws-lambda@8.10.119:
+    resolution: {integrity: sha512-Vqm22aZrCvCd6I5g1SvpW151jfqwTzEZ7XJ3yZ6xaZG31nUEOEyzzVImjRcsN8Wi/QyPxId/x8GTtgIbsy8kEw==}
     dev: true
 
   /@types/babel__core@7.20.0:

--- a/stopHandler.ts
+++ b/stopHandler.ts
@@ -7,5 +7,5 @@ const client = new EC2Client({});
 const instanceId = process.env[StopperEnvVar.InstanceId];
 
 export const handler: Handler<void, void> = async () => {
-    await stopInstance(client, instanceId as string);
-}
+  await stopInstance(client, instanceId as string);
+};

--- a/stopHandler.ts
+++ b/stopHandler.ts
@@ -1,0 +1,11 @@
+import { EC2Client } from "@aws-sdk/client-ec2";
+import { Handler } from "aws-lambda";
+import { stopInstance } from "./stopInstance";
+import { StopperEnvVar } from "./StopperEnvVar";
+
+const client = new EC2Client({});
+const instanceId = process.env[StopperEnvVar.InstanceId];
+
+export const handler: Handler<void, void> = async () => {
+    await stopInstance(client, instanceId as string);
+}

--- a/stopInstance.ts
+++ b/stopInstance.ts
@@ -1,0 +1,24 @@
+import { EC2Client, EC2ServiceException, StopInstancesCommand } from "@aws-sdk/client-ec2";
+
+export async function stopInstance(client: EC2Client, instanceId: string): Promise<void> {
+    const request = {
+        InstanceIds: [instanceId],
+      };
+      try {
+        await client.send(
+          new StopInstancesCommand({
+            ...request,
+            Hibernate: true,
+          })
+        );
+      } catch (err) {
+        if (
+          (err as EC2ServiceException).name ===
+          "UnsupportedHibernationConfiguration"
+        ) {
+          await client.send(new StopInstancesCommand(request));
+        } else {
+          throw err;
+        }
+      }
+}

--- a/stopInstance.ts
+++ b/stopInstance.ts
@@ -1,24 +1,31 @@
-import { EC2Client, EC2ServiceException, StopInstancesCommand } from "@aws-sdk/client-ec2";
+import {
+  EC2Client,
+  EC2ServiceException,
+  StopInstancesCommand,
+} from "@aws-sdk/client-ec2";
 
-export async function stopInstance(client: EC2Client, instanceId: string): Promise<void> {
-    const request = {
-        InstanceIds: [instanceId],
-      };
-      try {
-        await client.send(
-          new StopInstancesCommand({
-            ...request,
-            Hibernate: true,
-          })
-        );
-      } catch (err) {
-        if (
-          (err as EC2ServiceException).name ===
-          "UnsupportedHibernationConfiguration"
-        ) {
-          await client.send(new StopInstancesCommand(request));
-        } else {
-          throw err;
-        }
-      }
+export async function stopInstance(
+  client: EC2Client,
+  instanceId: string
+): Promise<void> {
+  const request = {
+    InstanceIds: [instanceId],
+  };
+  try {
+    await client.send(
+      new StopInstancesCommand({
+        ...request,
+        Hibernate: true,
+      })
+    );
+  } catch (err) {
+    if (
+      (err as EC2ServiceException).name ===
+      "UnsupportedHibernationConfiguration"
+    ) {
+      await client.send(new StopInstancesCommand(request));
+    } else {
+      throw err;
+    }
+  }
 }


### PR DESCRIPTION
* Enable hibernation for supported instance types on deployment
* Attempt to hibernate instances when the stop command is issued and fall back to normal shut-down if that fails
* Use a lambda to auto-hibernate/stop instances (since this isn't supported as a Cloudwatch action)